### PR TITLE
Add style checking to build using Flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ jobs:
           name: build
           command: docker build --cache-from fakenewsdetector/robinho -t fakenewsdetector/robinho .
       - run:
+          name: run style check
+          command: docker run --rm fakenewsdetector/robinho flake8 robinho/
+      - run:
           name: run tests
           command: docker run --rm fakenewsdetector/robinho python3 -m unittest
       - deploy:

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 data/*
 !data/.gitkeep
 __pycache__
+
+.idea

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@
 build:
 	docker build --cache-from registry.heroku.com/robinho/web:latest -t registry.heroku.com/robinho/web .
 
-test: build
+stylecheck: build
+	docker run --rm registry.heroku.com/robinho/web flake8 robinho/
+
+test: stylecheck
 	docker run --rm registry.heroku.com/robinho/web python3 -m unittest
 
 run: build

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sklearn
 imblearn
 tornado
 jupyter
+flake8

--- a/robinho/classifiers/base.py
+++ b/robinho/classifiers/base.py
@@ -9,7 +9,7 @@ class BaseClassifier():
         try:
             with open('data/' + self.name + '.pkl', "rb") as f:
                 self.clf = pickle.load(f)
-        except:
+        except FileNotFoundError:
             self.train()
 
     def features_labels(self):
@@ -27,7 +27,7 @@ class BaseClassifier():
     def load_links(self):
         try:
             df = pd.read_csv("data/links.csv")
-        except:
+        except FileNotFoundError:
             print("Downloading links data...")
             df = pd.read_json(
                 "https://api.fakenewsdetector.org/links/all")

--- a/robinho/classifiers/click_bait.py
+++ b/robinho/classifiers/click_bait.py
@@ -5,7 +5,6 @@ from sklearn.naive_bayes import MultinomialNB
 from sklearn.feature_extraction.text import TfidfTransformer
 from imblearn.under_sampling import RandomUnderSampler
 from imblearn.pipeline import Pipeline
-from sklearn.pipeline import FeatureUnion
 from sklearn.preprocessing import FunctionTransformer
 
 


### PR DESCRIPTION
This PR adds a Makefile target to check the source code for style issues using Flake8, which is called prior to running the tests and fails the build if the source code doesn't conform to proper Python style (it also adds PyCharm's project files to .gitignore because I was using this IDE to make these changes). 
The current issues that were found by Flake8 (one unused import and a too broad `except` clause) is also already fixed by this PR.
