### PR TITLE
Adds random seed to classifiers

### DIFF
--- a/robinho/classifiers/base.py
+++ b/robinho/classifiers/base.py
@@ -3,6 +3,8 @@ import pickle
 
 
 class BaseClassifier():
+    RANDOM_SEED = 123
+
     def __init__(self):
         try:
             with open('data/' + self.name + '.pkl', "rb") as f:

--- a/robinho/classifiers/click_bait.py
+++ b/robinho/classifiers/click_bait.py
@@ -30,6 +30,6 @@ class ClickBait(BaseClassifier):
             ('selector', FunctionTransformer(self.extract_title, validate=False)),
             ('vect', CountVectorizer(ngram_range=(2, 1))),
             ('tfidf', TfidfTransformer()),
-            ('sampling', RandomUnderSampler()),
+            ('sampling', RandomUnderSampler(random_state=BaseClassifier.RANDOM_SEED)),
             ('clf', MultinomialNB()),
         ])

--- a/robinho/classifiers/extremely_biased.py
+++ b/robinho/classifiers/extremely_biased.py
@@ -45,6 +45,6 @@ class ExtremelyBiased(BaseClassifier):
                     'content': 1.0,
                 },
             )),
-            ('sampling', RandomUnderSampler()),
+            ('sampling', RandomUnderSampler(random_state=BaseClassifier.RANDOM_SEED)),
             ('clf', MultinomialNB())
         ])

--- a/robinho/classifiers/fake_news.py
+++ b/robinho/classifiers/fake_news.py
@@ -45,6 +45,6 @@ class FakeNews(BaseClassifier):
                     'content': 1.0,
                 },
             )),
-            ('sampling', RandomUnderSampler()),
+            ('sampling', RandomUnderSampler(random_state=BaseClassifier.RANDOM_SEED)),
             ('clf', MultinomialNB())
         ])


### PR DESCRIPTION
After running the tests several times, I noticed that some of them often failed because the scores obtained by the classifiers varied a little on each execution. This is probably happening because the `RandomUnderSampler` used by them doesn't have a random seed set, so it may yield different datasets every time the classifier gets trained and may result on slightly different scores on each execution of the tests suite.

This PR adds a fixed random seed to the classifiers to make the results reproducible (I've ran the tests ten times after adding the random seed and managed to get consistent results across the executions, so it seems to have achieved the intended effect).